### PR TITLE
Just use ExtUtils::MakeMaker

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,7 +34,6 @@ module = HTTP::Tiny::Mech
 module = WWW::Mechanize::Cached
 copy_to = develop.requires
 
-[ModuleBuild]
 [PodWeaver]
 [ReadmeFromPod]
 [MetaJSON]


### PR DESCRIPTION
Module::Build is no longer in core, and it is not a great idea to use both Module::Build and ExtUtils::MakeMaker (e.g. see http://neilb.org/2015/05/18/two-build-files-considered-harmful.html). Since Dist::Zilla is in use here, it is very easy to just use EUMM.